### PR TITLE
Move to a ubi8/ubi-minimal

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN GOOS=linux CGO_ENABLED=e go build -o /capabilities-demo \
         github.com/maiqueb/fosdem2021-capabilities-demo/cmd
 
-FROM fedora:32
-RUN dnf install -y iproute \
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+RUN microdnf install -y iproute \
     procps-ng
 COPY --from=builder /capabilities-demo /capabilities-demo


### PR DESCRIPTION
The ubi8 container image 'weights' a lot less than the fedora:32
img being used previously.
